### PR TITLE
Added submodule to src/p2f

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/abc"]
 	path = third-party/abc
 	url = ../../The-OpenROAD-Project/abc.git
+[submodule "src/p2f"]
+	path = src/p2f
+	url = https://github.com/vishnu-p2f/p2f-tool.git


### PR DESCRIPTION
This pull request adds the p2f-tool repository as a Git submodule under src/p2f.

Changes:
- Added submodule pointing to https://github.com/vishnu-p2f/p2f-tool.git
- Updated .gitmodules and src/p2f tracking
- Prepares OpenROAD to integrate with p2f